### PR TITLE
fix mobile/desktop toggle behavior

### DIFF
--- a/ASoIaF-events.js
+++ b/ASoIaF-events.js
@@ -498,10 +498,15 @@ $(function () {
   });
 
   //Mobile Interface
-  $('#menuButton, #returnToMap, .ui-li a, #lightboxLink').click(function () {
-    $('#map_canvas, #menuButton, #filter').toggle();
-    ga('send', 'event', 'navigation', 'toggle', 'mobileMenu');
-  });
+  var isMobile = window.matchMedia("only screen and (max-device-width: 480px)").matches;
+  
+  if (isMobile) {
+    $('#menuButton, #returnToMap, .ui-li a, #lightboxLink').click(function () {
+      $('#map_canvas, #menuButton, #filter').toggle();
+      ga('send', 'event', 'navigation', 'toggle', 'mobileMenu');
+    });
+  }
+  
   $('#showCharacterPaths, #closeCharList').click(function () {
     $('#handheldToggles, #filter').toggle();
     ga('send', 'event', 'navigation', 'toggle', 'mobileCharacters');


### PR DESCRIPTION
This PR fixes the white background issue on desktop.

The problem occurs due to the menu toggle being activated when a desktop user clicks on a result in the town selector. This change fixes this by detecting mobile devices using window.matchMedia, and only toggling the menu when the watchMedia is "only screen and (max-device-width: 480px)".

This has been tested to work on mobile and desktop using Firefox's Responsive Design Mode.